### PR TITLE
Add death type tracking

### DIFF
--- a/project/autoloads/character_data.gd
+++ b/project/autoloads/character_data.gd
@@ -1,6 +1,22 @@
 extends Node
 
+signal player_died(death_type: DeathType)
+
+enum DeathType {
+	IDLE,
+	RABIES,
+	STEAM_ROLLER,
+}
+
+var ways_died: Dictionary = {}
+
 var appearance: CharacterAppearanceData = CharacterAppearanceData.new()
 
-func _enter_tree() -> void:
-	pass
+func _ready() -> void:
+	player_died.connect(_on_player_died)
+
+func _on_player_died(death_type: DeathType) -> void:
+	ways_died[death_type] = true
+
+func has_already_died_by(death_type: DeathType) -> bool:
+	return ways_died.has(death_type)


### PR DESCRIPTION
This adds a simple death tracking system with some types. 
This will help make sure the player can only die each way once.